### PR TITLE
Tinned compiling with gcc

### DIFF
--- a/include/Tinned/KeepVisitor.hpp
+++ b/include/Tinned/KeepVisitor.hpp
@@ -57,7 +57,24 @@ namespace Tinned
                 SymEngine::vec_basic &f_args,
                 bool &has_arg_kept,
                 bool &has_arg_affected,
-                const Arg &arg);
+                const Arg &arg)
+            {
+                auto new_arg = apply(arg);
+                // If there exists an argument being kept, all other arguments
+                // and the function will be kept. So we save all arguments to
+                // be removed for later use.
+                if (new_arg.is_null())
+                {
+                    f_args.push_back(arg);
+                }
+                else
+                {
+                    f_args.push_back(new_arg);
+                    has_arg_kept = true;
+                    if (SymEngine::neq(*arg, *new_arg))
+                        has_arg_affected = true;
+                }
+            }
 
             // Function template for one or more arguments. `f_args` holds all
             // arguments, either affected or unaffected after removal.
@@ -167,30 +184,6 @@ namespace Tinned
         auto result = visitor.apply(x);
         if (result.is_null()) return result;
         return remove_zero_quantities ? remove_zeros(result) : result;
-    }
-    // Function template for only one argument.
-    template <typename Arg>
-    inline void KeepVisitor::keep_if_arguments(
-        SymEngine::vec_basic &f_args,
-        bool &has_arg_kept,
-        bool &has_arg_affected,
-        const Arg &arg)
-    {
-        auto new_arg = apply(arg);
-        // If there exists an argument being kept, all other arguments
-        // and the function will be kept. So we save all arguments to
-        // be removed for later use.
-        if (new_arg.is_null())
-        {
-            f_args.push_back(arg);
-        }
-        else
-        {
-            f_args.push_back(new_arg);
-            has_arg_kept = true;
-            if (SymEngine::neq(*arg, *new_arg))
-                has_arg_affected = true;
-        }
     }
 
     // Function template for only one argument of type `SymEngine::vec_basic`.

--- a/include/Tinned/KeepVisitor.hpp
+++ b/include/Tinned/KeepVisitor.hpp
@@ -74,12 +74,11 @@ namespace Tinned
             }
 
             // Function template for only one argument of type `SymEngine::vec_basic`.
-            template<> inline void keep_if_arguments<SymEngine::vec_basic>(
-                SymEngine::vec_basic& f_args,
-                bool& has_arg_kept,
-                bool& has_arg_affected,
-                const SymEngine::vec_basic& arg
-            )
+            inline void keep_if_arguments(
+                SymEngine::vec_basic &f_args,
+                bool &has_arg_kept,
+                bool &has_arg_affected,
+                const SymEngine::vec_basic &arg)
             {
                 for (const auto& term: arg)
                     keep_if_arguments(f_args, has_arg_kept, has_arg_affected, term);

--- a/include/Tinned/KeepVisitor.hpp
+++ b/include/Tinned/KeepVisitor.hpp
@@ -52,50 +52,24 @@ namespace Tinned
             }
 
             // Function template for only one argument.
-            template<typename Arg> inline void keep_if_arguments(
-                SymEngine::vec_basic& f_args,
-                bool& has_arg_kept,
-                bool& has_arg_affected,
-                const Arg& arg
-            )
-            {
-                auto new_arg = apply(arg);
-                // If there exists an argument being kept, all other arguments
-                // and the function will be kept. So we save all arguments to
-                // be removed for later use.
-                if (new_arg.is_null()) {
-                    f_args.push_back(arg);
-                }
-                else {
-                    f_args.push_back(new_arg);
-                    has_arg_kept = true;
-                    if (SymEngine::neq(*arg, *new_arg)) has_arg_affected = true;
-                }
-            }
-
-            // Function template for only one argument of type `SymEngine::vec_basic`.
+            template <typename Arg>
             inline void keep_if_arguments(
                 SymEngine::vec_basic &f_args,
                 bool &has_arg_kept,
                 bool &has_arg_affected,
-                const SymEngine::vec_basic &arg)
-            {
-                for (const auto& term: arg)
-                    keep_if_arguments(f_args, has_arg_kept, has_arg_affected, term);
-            }
+                const Arg &arg);
 
             // Function template for one or more arguments. `f_args` holds all
             // arguments, either affected or unaffected after removal.
             // `has_arg_kept` indicates if one or more arguments are kept.
             // `has_arg_affected` indicates if one or more arguments are
             // affected due to removal.
-            template<typename FirstArg, typename... Args>
+            template <typename FirstArg, typename... Args>
             inline void keep_if_arguments(
-                SymEngine::vec_basic& f_args,
-                bool& has_arg_kept,
-                bool& has_arg_affected,
-                const FirstArg& first_arg, const Args&... args
-            )
+                SymEngine::vec_basic &f_args,
+                bool &has_arg_kept,
+                bool &has_arg_affected,
+                const FirstArg &first_arg, const Args &...args)
             {
                 keep_if_arguments(f_args, has_arg_kept, has_arg_affected, first_arg);
                 keep_if_arguments(f_args, has_arg_kept, has_arg_affected, args...);
@@ -193,5 +167,41 @@ namespace Tinned
         auto result = visitor.apply(x);
         if (result.is_null()) return result;
         return remove_zero_quantities ? remove_zeros(result) : result;
+    }
+    // Function template for only one argument.
+    template <typename Arg>
+    inline void KeepVisitor::keep_if_arguments(
+        SymEngine::vec_basic &f_args,
+        bool &has_arg_kept,
+        bool &has_arg_affected,
+        const Arg &arg)
+    {
+        auto new_arg = apply(arg);
+        // If there exists an argument being kept, all other arguments
+        // and the function will be kept. So we save all arguments to
+        // be removed for later use.
+        if (new_arg.is_null())
+        {
+            f_args.push_back(arg);
+        }
+        else
+        {
+            f_args.push_back(new_arg);
+            has_arg_kept = true;
+            if (SymEngine::neq(*arg, *new_arg))
+                has_arg_affected = true;
+        }
+    }
+
+    // Function template for only one argument of type `SymEngine::vec_basic`.
+    template <>
+    inline void KeepVisitor::keep_if_arguments<SymEngine::vec_basic>(
+        SymEngine::vec_basic &f_args,
+        bool &has_arg_kept,
+        bool &has_arg_affected,
+        const SymEngine::vec_basic &arg)
+    {
+        for (const auto &term : arg)
+            keep_if_arguments(f_args, has_arg_kept, has_arg_affected, term);
     }
 }

--- a/include/Tinned/ReplaceVisitor.hpp
+++ b/include/Tinned/ReplaceVisitor.hpp
@@ -72,11 +72,10 @@ namespace Tinned
             }
 
             // Function template for only one argument of type `SymEngine::vec_basic`.
-            template<> inline void replace_arguments<SymEngine::vec_basic>(
-                SymEngine::vec_basic& f_args,
-                bool& has_arg_replaced,
-                const SymEngine::vec_basic& arg
-            )
+            inline void replace_arguments(
+                SymEngine::vec_basic &f_args,
+                bool &has_arg_replaced,
+                const SymEngine::vec_basic &arg)
             {
                 for (const auto& term: arg)
                     replace_arguments(f_args, has_arg_replaced, term);

--- a/include/Tinned/ReplaceVisitor.hpp
+++ b/include/Tinned/ReplaceVisitor.hpp
@@ -60,26 +60,11 @@ namespace Tinned
             }
 
             // Function template for replacing one argument.
-            template<typename Arg> inline void replace_arguments(
-                SymEngine::vec_basic& f_args,
-                bool& has_arg_replaced,
-                const Arg& arg
-            )
-            {
-                auto new_arg = apply(arg);
-                f_args.push_back(new_arg);
-                if (SymEngine::neq(*arg, *new_arg)) has_arg_replaced = true;
-            }
-
-            // Function template for only one argument of type `SymEngine::vec_basic`.
+            template <typename Arg>
             inline void replace_arguments(
                 SymEngine::vec_basic &f_args,
                 bool &has_arg_replaced,
-                const SymEngine::vec_basic &arg)
-            {
-                for (const auto& term: arg)
-                    replace_arguments(f_args, has_arg_replaced, term);
-            }
+                const Arg &arg);
 
             // Function template for replacing one or more arguments. `f_args`
             // holds all arguments, either replaced or original ones.
@@ -193,5 +178,29 @@ namespace Tinned
         }
         if (diff_subs_dict.empty()) return x;
         return replace(x, diff_subs_dict);
+    }
+
+    // Function template for replacing one argument.
+    template <typename Arg>
+    inline void ReplaceVisitor::replace_arguments(
+        SymEngine::vec_basic &f_args,
+        bool &has_arg_replaced,
+        const Arg &arg)
+    {
+        auto new_arg = apply(arg);
+        f_args.push_back(new_arg);
+        if (SymEngine::neq(*arg, *new_arg))
+            has_arg_replaced = true;
+    }
+
+    // Function template for only one argument of type `SymEngine::vec_basic`.
+    template <>
+    inline void ReplaceVisitor::replace_arguments<SymEngine::vec_basic>(
+        SymEngine::vec_basic &f_args,
+        bool &has_arg_replaced,
+        const SymEngine::vec_basic &arg)
+    {
+        for (const auto &term : arg)
+            replace_arguments(f_args, has_arg_replaced, term);
     }
 }

--- a/include/Tinned/ReplaceVisitor.hpp
+++ b/include/Tinned/ReplaceVisitor.hpp
@@ -64,7 +64,13 @@ namespace Tinned
             inline void replace_arguments(
                 SymEngine::vec_basic &f_args,
                 bool &has_arg_replaced,
-                const Arg &arg);
+                const Arg &arg)
+            {
+                auto new_arg = apply(arg);
+                f_args.push_back(new_arg);
+                if (SymEngine::neq(*arg, *new_arg))
+                    has_arg_replaced = true;
+            }
 
             // Function template for replacing one or more arguments. `f_args`
             // holds all arguments, either replaced or original ones.
@@ -178,19 +184,6 @@ namespace Tinned
         }
         if (diff_subs_dict.empty()) return x;
         return replace(x, diff_subs_dict);
-    }
-
-    // Function template for replacing one argument.
-    template <typename Arg>
-    inline void ReplaceVisitor::replace_arguments(
-        SymEngine::vec_basic &f_args,
-        bool &has_arg_replaced,
-        const Arg &arg)
-    {
-        auto new_arg = apply(arg);
-        f_args.push_back(new_arg);
-        if (SymEngine::neq(*arg, *new_arg))
-            has_arg_replaced = true;
     }
 
     // Function template for only one argument of type `SymEngine::vec_basic`.


### PR DESCRIPTION
It seems that the template specialization is only supported by Clang and other select compilers. 
This version is passing tests as well. 
I am not sure I understand the need for template function specialization over overloading. 

@bingao Could you explain this to me before you merge this?